### PR TITLE
Build debug apk on development push

### DIFF
--- a/.github/workflows/android-preview-pr.yml
+++ b/.github/workflows/android-preview-pr.yml
@@ -1,0 +1,35 @@
+on:
+  push:
+    branches:
+      - development
+    paths:
+     - "androidApp/**"
+     - "shared/**"
+     - "buildSrc/**"
+     - ".github/workflows/android-preview-pr.yml"
+jobs:
+  build_android_debug:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: build android app
+        run: ./gradlew :androidApp:assembleDebug
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: apk
+          path: androidApp/build/outputs/apk/debug/androidApp-debug.apk
+
+      - name: Upload artifact to Firebase App Distribution
+        uses: wzieba/Firebase-Distribution-Github-Action@v1
+        with:
+          appId: ${{secrets.FIREBASE_ANDROID_APP_ID}}
+          token: ${{secrets.FIREBASE_TOKEN}}
+          groups: dev-team
+          file: androidApp/build/outputs/apk/debug/androidApp-debug.apk


### PR DESCRIPTION
Deploying the debug apk to firebase distribution on push to the development branch.

Considered doing it for every PR, but not sure how useful that would be