### PR TITLE
Split Navigation Activity Flow

### DIFF
--- a/android/app-project-newm/src/androidTest/java/io/projectnewm/LoginScreenTest.kt
+++ b/android/app-project-newm/src/androidTest/java/io/projectnewm/LoginScreenTest.kt
@@ -11,7 +11,7 @@ import org.junit.Test
 class LoginScreenTest : ScreenshotTest {
 
     @get:Rule
-    val composeTestRule = createAndroidComposeRule<MainActivity>()
+    val composeTestRule = createAndroidComposeRule<LoginActivity>()
 
     @Before
     fun setup() {

--- a/android/app-project-newm/src/androidTest/java/io/projectnewm/NewmAppComposableTest.kt
+++ b/android/app-project-newm/src/androidTest/java/io/projectnewm/NewmAppComposableTest.kt
@@ -15,7 +15,7 @@ import org.junit.Test
 class NewmAppComposableTest {
 
     @get:Rule
-    val composeTestRule = createAndroidComposeRule<MainActivity>()
+    val composeTestRule = createAndroidComposeRule<LoginActivity>()
 
 
     @Before

--- a/android/app-project-newm/src/main/AndroidManifest.xml
+++ b/android/app-project-newm/src/main/AndroidManifest.xml
@@ -1,26 +1,37 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    android:sharedUserId="io.projectnewm.uid"
-    package="io.projectnewm">
+        android:sharedUserId="io.projectnewm.uid"
+        package="io.projectnewm">
 
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application
-        android:name=".NewmApplication"
-        android:allowBackup="true"
-        android:icon="@mipmap/ic_launcher"
-        android:label="@string/app_name"
-        android:roundIcon="@mipmap/ic_launcher_round"
-        android:supportsRtl="true"
-        android:theme="@style/Theme.ProjectNewm.SplashScreen">
+            android:name=".NewmApplication"
+            android:allowBackup="true"
+            android:icon="@mipmap/ic_launcher"
+            android:label="@string/app_name"
+            android:roundIcon="@mipmap/ic_launcher_round"
+            android:supportsRtl="true"
+            android:theme="@style/Theme.ProjectNewm.SplashScreen">
         <activity
-            android:name=".MainActivity"
-            android:exported="true"
-            android:theme="@style/Theme.ProjectNewm.SplashScreen.NoActionBar">
+                android:name=".LaunchNewmActivity"
+                android:exported="true"
+                android:screenOrientation="portrait"
+                android:theme="@style/Theme.ProjectNewm.SplashScreen.NoActionBar">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <activity
+                android:name=".HomeActivity"
+                android:launchMode="singleTop"
+                android:screenOrientation="portrait" />
+
+        <activity
+                android:name=".LoginActivity"
+                android:launchMode="singleTop"
+                android:screenOrientation="portrait" />
     </application>
 </manifest>

--- a/android/app-project-newm/src/main/java/io/projectnewm/HomeActivity.kt
+++ b/android/app-project-newm/src/main/java/io/projectnewm/HomeActivity.kt
@@ -1,0 +1,25 @@
+package io.projectnewm
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.runtime.Composable
+import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import io.projectnewm.core.theme.NewmMobileTheme
+import io.projectnewm.feature.login.screen.*
+import io.projectnewm.screens.Screen
+
+class HomeActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            NewmMobileTheme {
+                NewmApp()
+            }
+        }
+    }
+}

--- a/android/app-project-newm/src/main/java/io/projectnewm/LaunchNewmActivity.kt
+++ b/android/app-project-newm/src/main/java/io/projectnewm/LaunchNewmActivity.kt
@@ -1,0 +1,36 @@
+package io.projectnewm
+
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+
+class LaunchNewmActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        installSplashScreen().apply {
+            setKeepOnScreenCondition { true }
+        }
+
+        if (isUserLoggedIn) {
+            launchHomeActivity()
+        } else {
+            launchLoginActivity()
+        }
+        finish()
+    }
+
+    private fun launchHomeActivity() {
+        startActivity(Intent(this@LaunchNewmActivity, HomeActivity::class.java))
+    }
+
+    private fun launchLoginActivity() {
+        startActivity(Intent(this@LaunchNewmActivity, LoginActivity::class.java))
+    }
+
+    //TODO: Replace with refresh token from db
+    companion object {
+        var isUserLoggedIn: Boolean = false
+    }
+}

--- a/android/app-project-newm/src/main/java/io/projectnewm/LoginActivity.kt
+++ b/android/app-project-newm/src/main/java/io/projectnewm/LoginActivity.kt
@@ -1,5 +1,6 @@
 package io.projectnewm
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -12,61 +13,45 @@ import io.projectnewm.core.theme.NewmMobileTheme
 import io.projectnewm.feature.login.screen.*
 import io.projectnewm.screens.Screen
 
-class MainActivity : ComponentActivity() {
+class LoginActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         installSplashScreen()
         setContent {
             NewmMobileTheme {
-                WelcomeToNewm()
+                WelcomeToNewm(::launchHomeActivity)
             }
         }
+    }
+
+    private fun launchHomeActivity() {
+        startActivity(Intent(this@LoginActivity, HomeActivity::class.java))
     }
 }
 
 @Composable
-fun WelcomeToNewm(signupViewModel: SignupViewModel = org.koin.androidx.compose.get()) {
+fun WelcomeToNewm(
+    onStartHomeActivity: () -> Unit,
+    signupViewModel: SignupViewModel = org.koin.androidx.compose.get()
+) {
     val navController = rememberNavController()
 
     NavHost(navController = navController, startDestination = Screen.LoginScreen.route) {
         composable(Screen.LoginScreen.route) {
-            LoginScreen(onUserLoggedIn = { ->
-                navController.navigate(Screen.HomeRoot.route) {
-                    popUpTo(Screen.LoginScreen.route) {
-                        inclusive = true
-                    }
-                }
-            }, onSignupClick = {
+            LoginScreen(onUserLoggedIn = onStartHomeActivity, onSignupClick = {
                 navController.navigate(Screen.Signup.route)
             })
         }
         composable(Screen.Signup.route) {
             SignUpScreen(
-                onUserLoggedIn = {
-                    navController.navigate(Screen.HomeRoot.route) {
-                        popUpTo(Screen.LoginScreen.route) {
-                            inclusive = true
-                        }
-                    }
-                },
-                onVerification = {
+                onUserLoggedIn = onStartHomeActivity, onVerification = {
                     navController.navigate(Screen.VerificationCode.route)
-                },
-                signupViewModel
+                }, signupViewModel
             )
         }
         composable(Screen.VerificationCode.route) {
-            VerificationScreen(signupViewModel) {
-                navController.navigate(Screen.HomeRoot.route) {
-                    popUpTo(Screen.LoginScreen.route) {
-                        inclusive = true
-                    }
-                }
-            }
-        }
-        composable(Screen.HomeRoot.route) {
-            NewmApp()
+            VerificationScreen(signupViewModel, onVerificationComplete = onStartHomeActivity)
         }
     }
 }


### PR DESCRIPTION
Split screen navigation flow into 3 different activities,
Launch Activity -  To decide if the user is in a logged in state or not
Login Activity for any pre auth flows
Home Activity to house the rest of the screen app flows