### PR TITLE
Jetpack Preferences Datastore in Kotlin Multiplatform Mobile (KMM)

### DIFF
--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -60,7 +60,7 @@ kotlin {
 				implementation(Ktor.clientContentNegotiation)
 				implementation(Ktor.kotlinXJson)
 				implementation(Ktor.clientAuth)
-				implementation("com.liftric:kvault:1.12.0")
+				implementation("androidx.datastore:datastore-preferences:1.1.1")
 			}
 		}
 		val commonTest by getting {

--- a/shared/src/androidMain/kotlin/io.newm.shared/internal/implementations/PreferencesDataStoreImpl.android.kt
+++ b/shared/src/androidMain/kotlin/io.newm.shared/internal/implementations/PreferencesDataStoreImpl.android.kt
@@ -1,0 +1,67 @@
+package io.newm.shared.internal.implementations
+
+import io.newm.shared.internal.db.PreferencesDataStore
+import android.content.Context
+import androidx.datastore.preferences.core.*
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+
+private val Context.dataStore by preferencesDataStore(name = "settings")
+
+class PreferencesDataStoreImpl(private val context: Context) : PreferencesDataStore {
+
+    override fun saveString(key: String, value: String) {
+        runBlocking {
+            context.dataStore.edit { preferences ->
+                preferences[stringPreferencesKey(key)] = value
+            }
+        }
+    }
+
+    override fun getString(key: String): String? {
+        return runBlocking {
+            val preferences = context.dataStore.data.first()
+            preferences[stringPreferencesKey(key)]
+        }
+    }
+
+    override fun saveInt(key: String, value: Int) {
+        runBlocking {
+            context.dataStore.edit { preferences ->
+                preferences[intPreferencesKey(key)] = value
+            }
+        }
+    }
+
+    override fun getInt(key: String): Int? {
+        return runBlocking {
+            val preferences = context.dataStore.data.first()
+            preferences[intPreferencesKey(key)]
+        }
+    }
+
+    override fun saveBoolean(key: String, value: Boolean) {
+        runBlocking {
+            context.dataStore.edit { preferences ->
+                preferences[booleanPreferencesKey(key)] = value
+            }
+        }
+    }
+
+    override fun getBoolean(key: String): Boolean? {
+        return runBlocking {
+            val preferences = context.dataStore.data.first()
+            preferences[booleanPreferencesKey(key)]
+        }
+    }
+
+    override fun deleteValue(key: String) {
+        runBlocking {
+            context.dataStore.edit { preferences ->
+                // Assuming string key for simplicity
+                preferences.remove(stringPreferencesKey(key))
+            }
+        }
+    }
+}

--- a/shared/src/androidMain/kotlin/shared/actual.kt
+++ b/shared/src/androidMain/kotlin/shared/actual.kt
@@ -1,10 +1,11 @@
 package shared
 
-import com.liftric.kvault.KVault
 import com.squareup.sqldelight.android.AndroidSqliteDriver
 import io.ktor.client.engine.android.Android
 import io.newm.shared.internal.db.NewmDatabaseWrapper
 import io.newm.shared.db.cache.NewmDatabase
+import io.newm.shared.internal.db.PreferencesDataStore
+import io.newm.shared.internal.implementations.PreferencesDataStoreImpl
 import org.koin.dsl.module
 
 actual fun platformModule() = module {
@@ -13,7 +14,7 @@ actual fun platformModule() = module {
         NewmDatabaseWrapper(NewmDatabase(driver))
     }
     single { Android.create() }
-    single { KVault(get(), fileName = "newm-encrypted-prefs") }
+    single<PreferencesDataStore> { PreferencesDataStoreImpl(get()) }
 }
 
 actual fun getPlatformName(): String = "Android"

--- a/shared/src/commonMain/kotlin/io.newm.shared/config/NewmSharedBuildConfigImpl.kt
+++ b/shared/src/commonMain/kotlin/io.newm.shared/config/NewmSharedBuildConfigImpl.kt
@@ -1,7 +1,7 @@
 package io.newm.shared.config
 
-import com.liftric.kvault.KVault
 import io.newm.shared.generated.BuildConfig
+import io.newm.shared.internal.db.PreferencesDataStore
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
@@ -18,14 +18,14 @@ class NewmSharedBuildConfigImpl: NewmSharedBuildConfig, KoinComponent {
 
     private val defaultMode = Mode.STAGING
 
-    private val storage: KVault by inject()
+    private val storage: PreferencesDataStore by inject()
     var mode: Mode
         get() {
-            val modeString = storage.string(APP_MODE) ?: defaultMode.name
+            val modeString = storage.getString(APP_MODE) ?: defaultMode.name
             return Mode.valueOf(modeString)
         }
         set(value) {
-            storage.set(APP_MODE, value.name)
+            storage.saveString(APP_MODE, value.name)
         }
 
     override val baseUrl: String

--- a/shared/src/commonMain/kotlin/io.newm.shared/internal/TokenManager.kt
+++ b/shared/src/commonMain/kotlin/io.newm.shared/internal/TokenManager.kt
@@ -2,11 +2,9 @@ package io.newm.shared.internal
 
 
 import co.touchlab.kermit.Logger
-import com.liftric.kvault.KVault
-import org.koin.core.component.KoinComponent
-import org.koin.core.component.inject
+import io.newm.shared.internal.db.PreferencesDataStore
 
-internal class TokenManager(private val storage: KVault) {
+internal class TokenManager(private val storage: PreferencesDataStore) {
     private val logger = Logger.withTag("NewmKMM-TokenManagerImpl")
 
     fun hasTokens(): Boolean {
@@ -14,27 +12,27 @@ internal class TokenManager(private val storage: KVault) {
     }
 
     fun getAccessToken(): String? {
-        return storage.string(ACCESS_TOKEN_KEY) ?: run {
+        return storage.getString(ACCESS_TOKEN_KEY) ?: run {
             logger.d("No Access Token found - Time to Login")
             null
         }
     }
 
     fun getRefreshToken(): String? {
-        return storage.string(REFRESH_TOKEN_KEY) ?: run {
+        return storage.getString(REFRESH_TOKEN_KEY) ?: run {
             logger.d("No Refresh Token found - Time to Login")
             null
         }
     }
 
     fun clearToken() {
-        storage.deleteObject(ACCESS_TOKEN_KEY)
-        storage.deleteObject(REFRESH_TOKEN_KEY)
+        storage.deleteValue(ACCESS_TOKEN_KEY)
+        storage.deleteValue(REFRESH_TOKEN_KEY)
     }
 
     fun setAuthTokens(accessToken: String, refreshToken: String) {
-        storage.set(ACCESS_TOKEN_KEY, accessToken)
-        storage.set(REFRESH_TOKEN_KEY, refreshToken)
+        storage.saveString(ACCESS_TOKEN_KEY, accessToken)
+        storage.saveString(REFRESH_TOKEN_KEY, refreshToken)
     }
 
     companion object {

--- a/shared/src/commonMain/kotlin/io.newm.shared/internal/db/PreferencesDataStore.kt
+++ b/shared/src/commonMain/kotlin/io.newm.shared/internal/db/PreferencesDataStore.kt
@@ -1,0 +1,11 @@
+package io.newm.shared.internal.db
+
+interface PreferencesDataStore {
+    fun saveString(key: String, value: String)
+    fun getString(key: String): String?
+    fun saveInt(key: String, value: Int)
+    fun getInt(key: String): Int?
+    fun saveBoolean(key: String, value: Boolean)
+    fun getBoolean(key: String): Boolean?
+    fun deleteValue(key: String)
+}

--- a/shared/src/commonMain/kotlin/io.newm.shared/internal/repositories/NewmPolicyIdsRepository.kt
+++ b/shared/src/commonMain/kotlin/io.newm.shared/internal/repositories/NewmPolicyIdsRepository.kt
@@ -1,6 +1,6 @@
 package io.newm.shared.internal.repositories
 
-import com.liftric.kvault.KVault
+import io.newm.shared.internal.db.PreferencesDataStore
 import io.newm.shared.internal.services.NewmPolicyIdsAPI
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
@@ -11,7 +11,7 @@ import kotlin.concurrent.Volatile
 
 internal class NewmPolicyIdsRepository(
     private val policyIdsAPI: NewmPolicyIdsAPI,
-    private val storage: KVault,
+    private val storage: PreferencesDataStore,
     private val scope: CoroutineScope,
 
     ) : KoinComponent {
@@ -26,7 +26,7 @@ internal class NewmPolicyIdsRepository(
 
     fun getPolicyIds(): Flow<List<String>> = flow {
         // Emit the locally stored IDs if available
-        val storedIds = storage.string(POLICY_IDS_KEY)
+        val storedIds = storage.getString(POLICY_IDS_KEY)
             ?: initialPolicyIdList.joinToString(",")
         if (storedIds.isNotEmpty()) {
             emit(storedIds.split(","))
@@ -38,7 +38,7 @@ internal class NewmPolicyIdsRepository(
             try {
                 val fetchedIds = policyIdsAPI.getNewmPolicyIds()
                 scope.launch {
-                    storage.set(POLICY_IDS_KEY, fetchedIds.joinToString(","))
+                    storage.saveString(POLICY_IDS_KEY, fetchedIds.joinToString(","))
                 }
                 emit(fetchedIds)
 

--- a/shared/src/iosMain/kotlin/io.newm.shared/internal/implementations/PreferencesDataStoreImpl.ios.kt.kt
+++ b/shared/src/iosMain/kotlin/io.newm.shared/internal/implementations/PreferencesDataStoreImpl.ios.kt.kt
@@ -1,0 +1,39 @@
+package io.newm.shared.internal.implementations
+
+import io.newm.shared.internal.db.PreferencesDataStore
+import platform.Foundation.NSUserDefaults
+
+class PreferencesDataStoreImpl : PreferencesDataStore {
+
+    private val userDefaults = NSUserDefaults.standardUserDefaults
+
+    override fun saveString(key: String, value: String) {
+        userDefaults.setObject(value, forKey = key)
+    }
+
+    override fun getString(key: String): String? {
+        return userDefaults.stringForKey(key)
+    }
+
+    override fun saveInt(key: String, value: Int) {
+        userDefaults.setInteger(value.toLong(), forKey = key)
+    }
+
+    override fun getInt(key: String): Int? {
+        val value = userDefaults.integerForKey(key)
+        return if (value.toInt() == 0 && userDefaults.objectForKey(key) == null) null else value.toInt()
+    }
+
+    override fun saveBoolean(key: String, value: Boolean) {
+        userDefaults.setBool(value, forKey = key)
+    }
+
+    override fun getBoolean(key: String): Boolean? {
+        val value = userDefaults.boolForKey(key)
+        return if (!value && userDefaults.objectForKey(key) == null) null else value
+    }
+
+    override fun deleteValue(key: String) {
+        userDefaults.removeObjectForKey(key)
+    }
+}

--- a/shared/src/iosMain/kotlin/shared/actual.kt
+++ b/shared/src/iosMain/kotlin/shared/actual.kt
@@ -1,10 +1,11 @@
 package shared
 
-import com.liftric.kvault.KVault
 import com.squareup.sqldelight.drivers.native.NativeSqliteDriver
 import io.ktor.client.engine.darwin.Darwin
 import io.newm.shared.db.cache.NewmDatabase
 import io.newm.shared.internal.db.NewmDatabaseWrapper
+import io.newm.shared.internal.db.PreferencesDataStore
+import io.newm.shared.internal.implementations.PreferencesDataStoreImpl
 import org.koin.dsl.module
 
 actual fun platformModule() = module {
@@ -13,7 +14,7 @@ actual fun platformModule() = module {
 		NewmDatabaseWrapper(NewmDatabase(driver))
 	}
     single { Darwin.create() }
-    single { KVault() }
+	single<PreferencesDataStore> { PreferencesDataStoreImpl() }
 }
 
 actual fun getPlatformName(): String = "iOS"


### PR DESCRIPTION
Replacing third party library KVault with a Google supported library.

With this change we will be able to surface the Preferences Datastore to both android and ios clients through  Koin