### PR TITLE
Fix disconnect wallets issue

### DIFF
--- a/shared/src/commonMain/kotlin/io.newm.shared/di/Koin.kt
+++ b/shared/src/commonMain/kotlin/io.newm.shared/di/Koin.kt
@@ -138,7 +138,7 @@ fun commonModule(enableNetworkLogs: Boolean) = module {
     single<ConnectWalletUseCase> { ConnectWalletUseCaseImpl(get(), get()) }
     single<UserSessionUseCase> { UserSessionUseCaseImpl(get()) }
     single<ConnectWalletUseCase> { ConnectWalletUseCaseImpl(get(), get()) }
-    single<DisconnectWalletUseCase> { DisconnectWalletUseCaseImpl(get(), get()) }
+    single<DisconnectWalletUseCase> { DisconnectWalletUseCaseImpl(get(), get(), get()) }
     single<SyncWalletConnectionsUseCase> { SyncWalletConnectionsUseCaseImpl(get()) }
     single<GetWalletConnectionsUseCase> { GetWalletConnectionsUseCaseImpl(get()) }
     single<HasWalletConnectionsUseCase> { HasWalletConnectionsUseCaseImpl(get()) }

--- a/shared/src/commonMain/kotlin/io.newm.shared/internal/repositories/WalletRepository.kt
+++ b/shared/src/commonMain/kotlin/io.newm.shared/internal/repositories/WalletRepository.kt
@@ -19,6 +19,7 @@ internal class WalletRepository(
     suspend fun syncWalletConnectionsFromNetworkToDB(): List<WalletConnection> {
         return try {
             val connections = networkService.getWalletConnections()
+            cacheService.deleteAllWalletConnections()
             cacheService.cacheWalletConnections(connections)
             connections
         } catch (e: Exception) {
@@ -42,7 +43,7 @@ internal class WalletRepository(
         try {
             val success = networkService.disconnectWallet(walletConnectionId)
             if (success) {
-                cacheService.deleteAllWalletConnections(walletConnectionId)
+                cacheService.deleteWalletConnectionsById(walletConnectionId)
             } else {
                 throw KMMException("Error disconnecting wallet")
             }

--- a/shared/src/commonMain/kotlin/io.newm.shared/internal/services/cache/WalletConnectionCacheService.kt
+++ b/shared/src/commonMain/kotlin/io.newm.shared/internal/services/cache/WalletConnectionCacheService.kt
@@ -3,10 +3,10 @@ package io.newm.shared.internal.services.cache
 import io.newm.shared.internal.services.db.NewmDatabaseWrapper
 import io.newm.shared.internal.services.db.cacheWalletConnections
 import io.newm.shared.internal.services.db.deleteAllWalletConnections
+import io.newm.shared.internal.services.db.deleteWalletConnectionById
 import io.newm.shared.internal.services.db.getWalletConnections
 import io.newm.shared.public.models.WalletConnection
 import kotlinx.coroutines.flow.Flow
-import org.koin.core.component.KoinComponent
 
 class WalletConnectionCacheService(
     private val db: NewmDatabaseWrapper
@@ -17,6 +17,9 @@ class WalletConnectionCacheService(
     suspend fun cacheWalletConnections(connections: List<WalletConnection>) =
         db.cacheWalletConnections(connections)
 
-    suspend fun deleteAllWalletConnections(connectionId: String) =
-        db.deleteAllWalletConnections(connectionId)
+    suspend fun deleteAllWalletConnections() =
+        db.deleteAllWalletConnections()
+
+    suspend fun deleteWalletConnectionsById(id: String) =
+        db.deleteWalletConnectionById(id)
 }

--- a/shared/src/commonMain/kotlin/io.newm.shared/internal/services/db/NewmDatabaseWrapperExt.kt
+++ b/shared/src/commonMain/kotlin/io.newm.shared/internal/services/db/NewmDatabaseWrapperExt.kt
@@ -99,8 +99,14 @@ fun NewmDatabaseWrapper.cacheWalletConnections(walletConnections: List<WalletCon
     }
 }
 
-fun NewmDatabaseWrapper.deleteAllWalletConnections(walletConnectionsId: String) {
+fun NewmDatabaseWrapper.deleteWalletConnectionById(walletConnectionsId: String) {
     invoke().transaction {
         invoke().walletConnectionQueries.deleteById(walletConnectionsId)
+    }
+}
+
+fun NewmDatabaseWrapper.deleteAllWalletConnections() {
+    invoke().transaction {
+        invoke().walletConnectionQueries.deleteAll()
     }
 }


### PR DESCRIPTION
Fixes wallet disconnect issue, when wallets were connected from different phones with the same account.

Now we call the network first to get the latest wallets connected to the newm user before we attempt to disconnect them, one by one.