### PR TITLE
Revert "Show loading indicator when nft tracks are being fetched from the network"

### DIFF
--- a/android/app-newm/src/main/java/io/newm/di/android/Dependencies.kt
+++ b/android/app-newm/src/main/java/io/newm/di/android/Dependencies.kt
@@ -9,7 +9,6 @@ import com.google.android.gms.common.Scopes
 import com.google.android.gms.common.api.Scope
 import io.newm.Logout
 import io.newm.RestartApp
-import io.newm.feature.login.screen.authproviders.RecaptchaClientProvider
 import io.newm.feature.login.screen.authproviders.google.GoogleSignInLauncher
 import io.newm.feature.login.screen.authproviders.google.GoogleSignInLauncherImpl
 import io.newm.feature.login.screen.createaccount.CreateAccountScreenPresenter
@@ -19,12 +18,14 @@ import io.newm.feature.login.screen.welcome.WelcomeScreenPresenter
 import io.newm.feature.musicplayer.repository.MockMusicRepository
 import io.newm.feature.musicplayer.repository.MusicRepository
 import io.newm.feature.musicplayer.viewmodel.MusicPlayerViewModel
-import io.newm.screens.forceupdate.ForceAppUpdatePresenter
 import io.newm.screens.home.categories.MusicalCategoriesViewModel
+import io.newm.feature.login.screen.authproviders.RecaptchaClientProvider
+import io.newm.screens.profile.view.ProfilePresenter
+import io.newm.screens.forceupdate.ForceAppUpdatePresenter
 import io.newm.screens.library.NFTLibraryPresenter
 import io.newm.screens.profile.edit.ProfileEditPresenter
-import io.newm.screens.profile.view.ProfilePresenter
 import io.newm.shared.config.NewmSharedBuildConfig
+import io.newm.shared.config.NewmSharedBuildConfigImpl
 import kotlinx.coroutines.FlowPreview
 import org.koin.android.ext.koin.androidContext
 import org.koin.androidx.viewmodel.dsl.viewModel
@@ -80,8 +81,7 @@ val viewModule = module {
             get(),
             get(),
             get(),
-            get(),
-            get(),
+            get()
         )
     }
     factory { params ->

--- a/shared/src/commonMain/kotlin/io.newm.shared/di/Koin.kt
+++ b/shared/src/commonMain/kotlin/io.newm.shared/di/Koin.kt
@@ -4,6 +4,23 @@ import io.ktor.client.engine.HttpClientEngine
 import io.newm.shared.config.NewmSharedBuildConfig
 import io.newm.shared.config.NewmSharedBuildConfigImpl
 import io.newm.shared.internal.TokenManager
+import io.newm.shared.internal.implementations.ChangePasswordUseCaseImpl
+import io.newm.shared.internal.implementations.ConnectWalletUseCaseImpl
+import io.newm.shared.internal.implementations.ForceAppUpdateUseCaseImpl
+import io.newm.shared.internal.implementations.GetGenresUseCaseImpl
+import io.newm.shared.internal.implementations.LoginUseCaseImpl
+import io.newm.shared.internal.implementations.ResetPasswordUseCaseImpl
+import io.newm.shared.internal.implementations.SignupUseCaseImpl
+import io.newm.shared.internal.implementations.UserDetailsUseCaseImpl
+import io.newm.shared.internal.implementations.UserSessionUseCaseImpl
+import io.newm.shared.internal.implementations.WalletNFTTracksUseCaseImpl
+import io.newm.shared.internal.repositories.GenresRepository
+import io.newm.shared.internal.repositories.LogInRepository
+import io.newm.shared.internal.repositories.RemoteConfigRepositoryImpl
+import io.newm.shared.internal.repositories.NewmPolicyIdsRepository
+import io.newm.shared.internal.repositories.PlaylistRepository
+import io.newm.shared.internal.repositories.RemoteConfigRepository
+import io.newm.shared.internal.repositories.UserRepository
 import io.newm.shared.internal.api.CardanoWalletAPI
 import io.newm.shared.internal.api.GenresAPI
 import io.newm.shared.internal.api.LoginAPI
@@ -11,28 +28,11 @@ import io.newm.shared.internal.api.NEWMWalletConnectionAPI
 import io.newm.shared.internal.api.NewmPolicyIdsAPI
 import io.newm.shared.internal.api.PlaylistAPI
 import io.newm.shared.internal.api.UserAPI
-import io.newm.shared.internal.implementations.ChangePasswordUseCaseImpl
-import io.newm.shared.internal.implementations.ConnectWalletUseCaseImpl
 import io.newm.shared.internal.implementations.DisconnectWalletUseCaseImpl
-import io.newm.shared.internal.implementations.ForceAppUpdateUseCaseImpl
-import io.newm.shared.internal.implementations.GetGenresUseCaseImpl
 import io.newm.shared.internal.implementations.GetWalletConnectionsUseCaseImpl
 import io.newm.shared.internal.implementations.HasWalletConnectionsUseCaseImpl
-import io.newm.shared.internal.implementations.LoginUseCaseImpl
-import io.newm.shared.internal.implementations.ResetPasswordUseCaseImpl
-import io.newm.shared.internal.implementations.SignupUseCaseImpl
 import io.newm.shared.internal.implementations.SyncWalletConnectionsUseCaseImpl
-import io.newm.shared.internal.implementations.UserDetailsUseCaseImpl
-import io.newm.shared.internal.implementations.UserSessionUseCaseImpl
-import io.newm.shared.internal.implementations.WalletNFTTracksUseCaseImpl
-import io.newm.shared.internal.repositories.GenresRepository
-import io.newm.shared.internal.repositories.LogInRepository
 import io.newm.shared.internal.repositories.NFTRepository
-import io.newm.shared.internal.repositories.NewmPolicyIdsRepository
-import io.newm.shared.internal.repositories.PlaylistRepository
-import io.newm.shared.internal.repositories.RemoteConfigRepository
-import io.newm.shared.internal.repositories.RemoteConfigRepositoryImpl
-import io.newm.shared.internal.repositories.UserRepository
 import io.newm.shared.internal.repositories.WalletRepository
 import io.newm.shared.internal.services.cache.NFTCacheService
 import io.newm.shared.internal.services.cache.NewmPolicyIdsCacheService
@@ -86,7 +86,6 @@ fun commonModule(enableNetworkLogs: Boolean) = module {
         )
     }
     single { CoroutineScope(Dispatchers.Default + SupervisorJob()) }
-
     single {
         createHttpClient(
             get(),
@@ -118,7 +117,7 @@ fun commonModule(enableNetworkLogs: Boolean) = module {
     single { NewmPolicyIdsCacheService(get()) }
     // Internal Repositories
     single { WalletRepository(get(), get()) }
-    single { NFTRepository(get(), get(), get(), get()) }
+    single { NFTRepository(get(), get(), get()) }
     single { GenresRepository() }
     single { LogInRepository() }
     single { NewmPolicyIdsRepository(get(), get(), get()) }

--- a/shared/src/commonMain/kotlin/io.newm.shared/internal/implementations/WalletNFTTracksUseCaseImpl.kt
+++ b/shared/src/commonMain/kotlin/io.newm.shared/internal/implementations/WalletNFTTracksUseCaseImpl.kt
@@ -7,25 +7,12 @@ import io.newm.shared.public.models.NFTTrack
 import io.newm.shared.public.models.error.KMMException
 import io.newm.shared.public.usecases.WalletNFTTracksUseCase
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.update
 import kotlin.coroutines.cancellation.CancellationException
 
 internal class WalletNFTTracksUseCaseImpl(
     private val nftRepository: NFTRepository,
 ) : WalletNFTTracksUseCase {
-
-    private var _hasEmptyWallet = MutableStateFlow(false)
-
-    override val hasEmptyWallet: Flow<Boolean> = _hasEmptyWallet.asStateFlow()
-
-    override fun setHasEmptyWallet(hasEmptyWallet: Boolean) {
-        _hasEmptyWallet.update {
-            hasEmptyWallet
-        }
-    }
 
     override fun getAllCollectableTracksFlow(): Flow<List<NFTTrack>> {
         return nftRepository.getAllCollectableTracksFlow()

--- a/shared/src/commonMain/kotlin/io.newm.shared/internal/repositories/NFTRepository.kt
+++ b/shared/src/commonMain/kotlin/io.newm.shared/internal/repositories/NFTRepository.kt
@@ -1,25 +1,25 @@
 package io.newm.shared.internal.repositories
 
+import co.touchlab.kermit.Logger
 import io.newm.shared.internal.services.cache.NFTCacheService
 import io.newm.shared.internal.services.network.NFTNetworkService
 import io.newm.shared.public.models.NFTTrack
-import io.newm.shared.public.usecases.WalletNFTTracksUseCase
+import io.newm.shared.public.models.error.KMMException
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
+import org.koin.core.component.KoinComponent
 
 internal class NFTRepository(
     private val networkService: NFTNetworkService,
     private val cacheService: NFTCacheService,
     private val policyIdsRepository: NewmPolicyIdsRepository,
-    private val walletNftTracksUseCase: WalletNFTTracksUseCase
 ) {
 
     suspend fun syncNFTTracksFromNetworkToDevice(): List<NFTTrack>? {
         return try {
-            walletNftTracksUseCase.setHasEmptyWallet(false)
             val nfts = networkService.getWalletNFTs()
             cacheService.cacheNFTTracks(nfts)
-            walletNftTracksUseCase.setHasEmptyWallet(nfts.isEmpty())
             nfts
         } catch (e: Exception) {
             throw e

--- a/shared/src/commonMain/kotlin/io.newm.shared/public/usecases/WalletNFTTracksUseCase.kt
+++ b/shared/src/commonMain/kotlin/io.newm.shared/public/usecases/WalletNFTTracksUseCase.kt
@@ -66,9 +66,6 @@ interface WalletNFTTracksUseCase {
 
     @Throws(KMMException::class, CancellationException::class)
     suspend fun refresh()
-
-    val hasEmptyWallet: Flow<Boolean>
-    fun setHasEmptyWallet(hasEmptyWallet: Boolean)
 }
 
 class WalletNFTTracksUseCaseProvider : KoinComponent {

--- a/shared/src/commonMain/kotlin/io.newm.shared/public/usecases/mocks/MockWalletNFTTracksUseCase.kt
+++ b/shared/src/commonMain/kotlin/io.newm.shared/public/usecases/mocks/MockWalletNFTTracksUseCase.kt
@@ -4,26 +4,12 @@ import io.newm.shared.public.models.NFTTrack
 import io.newm.shared.public.models.mocks.mockTracks
 import io.newm.shared.public.usecases.WalletNFTTracksUseCase
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.update
 
 class MockWalletNFTTracksUseCase: WalletNFTTracksUseCase {
 
     override suspend fun refresh() {
         // no-op
-    }
-
-    private var _hasEmptyWallet = MutableStateFlow(false)
-
-    override val hasEmptyWallet: Flow<Boolean>
-        get() = _hasEmptyWallet.asStateFlow()
-
-    override fun setHasEmptyWallet(hasEmptyWallet: Boolean) {
-        _hasEmptyWallet.update {
-            hasEmptyWallet
-        }
     }
 
     override fun getAllCollectableTracksFlow(): Flow<List<NFTTrack>> {


### PR DESCRIPTION
Reverts projectNEWM/newm-mobile#267

There was an interesting circular dependency when we use `WalletNFTTracksUseCase` inside the Repository,

We are not supposed to use use cases in repositories, ideally we only use use cases from the clients, 


@newmskywalker I completely missed that detail when reviewing the PR, but essentially when we use usecases on the repository the DI errors out. 
