### PR TITLE
Fix google sign in on Android

### DIFF
--- a/shared/src/commonMain/kotlin/io.newm.shared/internal/api/models/Users.kt
+++ b/shared/src/commonMain/kotlin/io.newm.shared/internal/api/models/Users.kt
@@ -9,7 +9,7 @@ internal data class LogInUser(
 )
 
 @Serializable
-internal data class GoogleSignInRequest(val accessToken: String)
+internal data class GoogleSignInRequest(val idToken: String)
 
 @Serializable
 internal data class AppleSignInRequest(val idToken: String)

--- a/shared/src/commonMain/kotlin/io.newm.shared/internal/repositories/LogInRepository.kt
+++ b/shared/src/commonMain/kotlin/io.newm.shared/internal/repositories/LogInRepository.kt
@@ -60,7 +60,7 @@ internal class LogInRepository : KoinComponent {
             when (oAuthData) {
                 is OAuthData.Facebook -> service.loginWithFacebook(FacebookSignInRequest(accessToken = oAuthData.accessToken))
                 is OAuthData.Google -> service.loginWithGoogle(
-                    GoogleSignInRequest(accessToken = oAuthData.idToken),
+                    GoogleSignInRequest(idToken = oAuthData.idToken),
                     humanVerificationCode
                 )
 


### PR DESCRIPTION
We're going to change iOS to support idToken instead of accessToken. I've updated the PR to rename the serializable class to use `idToken` to get Android into a working state in the mean time.


> It appears that Google Sign-In for Android stopped working after we implemented Google Sign-In for iOS. 
> Android needs to send an `idToken`, while iOS should send an `accessToken`. 
> 
> Since both platforms shared the same network request logic, the Android app was serializing the token as `accessToken` instead of the correct `idToken`.
> 
> This PR introduces an expected class to handle the platform-specific tokens, ensuring that Android sends the `idToken` and iOS sends `accessToken`.
> 
> Additionally, I had to update the GOOGLE_AUTH_CLIENT_ID environment variable. However, I wasn't able to test the changes on iOS, so we should verify that iOS functionality still works with the new value before merging this PR.





