### PR TITLE
Fix nft library crash when network request fails

### DIFF
--- a/shared/src/commonMain/kotlin/io.newm.shared/internal/repositories/NFTRepository.kt
+++ b/shared/src/commonMain/kotlin/io.newm.shared/internal/repositories/NFTRepository.kt
@@ -5,10 +5,12 @@ import io.newm.shared.public.models.NFTTrack
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.filterNot
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import org.mobilenativefoundation.store.core5.ExperimentalStoreApi
 import org.mobilenativefoundation.store.store5.StoreReadRequest
-import org.mobilenativefoundation.store.store5.impl.extensions.fresh
+import org.mobilenativefoundation.store.store5.StoreReadResponse
 
 internal class NFTRepository(
     private val nftStore: NftTrackStore
@@ -20,10 +22,12 @@ internal class NFTRepository(
     val isSynced: Flow<Boolean>
         get() = _syncedNftWallet.asStateFlow()
 
-    suspend fun syncNFTTracksFromNetworkToDevice(): List<NFTTrack> {
-        return nftStore.fresh(Unit).also {
-            _syncedNftWallet.value = true
-        }
+    suspend fun syncNFTTracksFromNetworkToDevice() {
+        nftStore.stream(StoreReadRequest.fresh(Unit))
+            .filterNot { it is StoreReadResponse.Loading }
+            .first()
+
+        _syncedNftWallet.value = true
     }
 
     fun getAllCollectableTracksFlow(): Flow<List<NFTTrack>> = getAll().map { tracks ->


### PR DESCRIPTION
When the device is in airplane mode (or the request fails for any other reason), nftStore.fresh crashes because it expects data to be returned.

This PR changes the functionality to use a stream which handles exceptions under the hood