### PR TITLE
Use suspendable store constructs to back suspendable use cases for NFT store

### DIFF
--- a/shared/src/commonMain/kotlin/io.newm.shared/internal/implementations/WalletNFTTracksUseCaseImpl.kt
+++ b/shared/src/commonMain/kotlin/io.newm.shared/internal/implementations/WalletNFTTracksUseCaseImpl.kt
@@ -22,7 +22,7 @@ internal class WalletNFTTracksUseCaseImpl(
     @Throws(KMMException::class, CancellationException::class)
     override suspend fun getAllCollectableTracks(): List<NFTTrack> {
         return mapErrorsSuspend {
-            return@mapErrorsSuspend nftRepository.getAllCollectableTracksFlow().first()
+            return@mapErrorsSuspend nftRepository.getAllCollectableTracks()
         }
     }
 
@@ -33,7 +33,7 @@ internal class WalletNFTTracksUseCaseImpl(
     @Throws(KMMException::class, CancellationException::class)
     override suspend fun getAllStreamTokens(): List<NFTTrack> {
         return mapErrorsSuspend {
-            return@mapErrorsSuspend nftRepository.getAllStreamTokensFlow().first()
+            return@mapErrorsSuspend nftRepository.getAllStreamTokens()
         }
     }
 

--- a/shared/src/commonMain/kotlin/io.newm.shared/internal/repositories/NFTRepository.kt
+++ b/shared/src/commonMain/kotlin/io.newm.shared/internal/repositories/NFTRepository.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.flow.map
 import org.mobilenativefoundation.store.core5.ExperimentalStoreApi
 import org.mobilenativefoundation.store.store5.StoreReadRequest
 import org.mobilenativefoundation.store.store5.StoreReadResponse
+import org.mobilenativefoundation.store.store5.impl.extensions.get
 
 internal class NFTRepository(
     private val nftStore: NftTrackStore
@@ -28,6 +29,14 @@ internal class NFTRepository(
             .first()
 
         _syncedNftWallet.value = true
+    }
+
+    suspend fun getAllCollectableTracks(): List<NFTTrack> {
+        return nftStore.get(Unit).filterNot { it.isStreamToken }
+    }
+
+    suspend fun getAllStreamTokens(): List<NFTTrack> {
+        return nftStore.get(Unit).filter { it.isStreamToken }
     }
 
     fun getAllCollectableTracksFlow(): Flow<List<NFTTrack>> = getAll().map { tracks ->


### PR DESCRIPTION
Since iOS does not currently support flows, we should not use a flow to back the suspendable use cases.
This change will return NFTs from the cache, or fetch from the network and update the cache