### PR TITLE
Introduced Automatic Versioning with Manual Control Over Major Versions

### DIFF
--- a/android/app-newm/build.gradle.kts
+++ b/android/app-newm/build.gradle.kts
@@ -131,44 +131,50 @@ sentry {
     telemetry.set(true)
 }
 
+
 /**
- * Generates a dynamic `versionCode` based on the current date and hour.
+ * Generates a version code based on the current date and time in the format `yyMMddHH`.
  *
- * The `versionCode` is constructed using the format `yyyyMMddHH`, which represents:
- * - `yyyy`: 4-digit year
- * - `MM`: 2-digit month (01-12)
- * - `dd`: 2-digit day of the month (01-31)
- * - `HH`: 2-digit hour in 24-hour format (00-23)
+ * The version code is an integer composed of:
+ * - `yy`: The last two digits of the current year.
+ * - `MM`: The current month.
+ * - `dd`: The current day of the month.
+ * - `HH`: The current hour (24-hour format).
  *
- * This ensures that each build has a unique `versionCode` per hour of the day.
+ * The function formats the current date and time using `SimpleDateFormat`,
+ * converts it into a string, and then parses it as an integer.
  *
- * @return An integer representing the dynamically generated `versionCode`.
+ * @return An integer representing the current date and time in the format `yyMMddHH`.
  */
 fun getCurrentDateTimeVersionCode(): Int {
-    val dateFormat = SimpleDateFormat("yyyyMMddHH")
+    val dateFormat = SimpleDateFormat("yyMMddHH")
     return dateFormat.format(Date()).toInt()
 }
 
 /**
- * Generates a dynamic `versionName` based on a specified major version, current year, month, day, and hour.
+ * Generates a custom version name based on the provided major version and the current date and time.
  *
- * The `versionName` follows the format `Major.Year.MMDDHH`, where:
- * - `Major`: The major version number provided as an input parameter.
- * - `Year`: The current year (e.g., 2024).
- * - `MMDD`: Month and day combined (e.g., 0925 for September 25).
- * - `HH`: Hour in 24-hour format (00-23).
+ * The version name follows the format: `major.YYYY.MMDDHHmm`, where:
+ * - `major`: The major version number passed as a parameter.
+ * - `YYYY`: The current year.
+ * - `MMDD`: The current month and day.
+ * - `HHmm`: The current hour and minute.
  *
- * @param major The major version number to be included in the `versionName`.
- * @return A string representing the dynamically generated `versionName`.
+ * The function retrieves the current date and time using `SimpleDateFormat` to format each component.
+ *
+ * @param major The major version number to be used as the first part of the version name.
+ * @return A custom version name string in the format: `major.YYYY.MMDDHHmm`.
  */
 fun getCustomVersionName(major: Int): String {
     val yearFormat = SimpleDateFormat("yyyy")
     val monthDayFormat = SimpleDateFormat("MMdd")
     val hourFormat = SimpleDateFormat("HH")
+    val minuteFormat = SimpleDateFormat("mm")
 
     val year = yearFormat.format(Date())
     val monthDay = monthDayFormat.format(Date())
     val hour = hourFormat.format(Date())
+    val minute = minuteFormat.format(Date())
 
-    return "$major.$year.$monthDay$hour"
+    return "$major.$year.$monthDay$hour$minute"
 }

--- a/android/app-newm/build.gradle.kts
+++ b/android/app-newm/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.text.SimpleDateFormat
+import java.util.Date
 
 apply(from = "../../gradle_include/compose.gradle")
 apply(from = "../../gradle_include/circuit.gradle")
@@ -5,7 +7,7 @@ apply(from = "../../gradle_include/flipper.gradle")
 
 plugins {
     id("com.android.application")
-    id( "com.google.gms.google-services")
+    id("com.google.gms.google-services")
     id("kotlin-parcelize")
     kotlin("android")
     kotlin("kapt")
@@ -23,8 +25,8 @@ android {
         applicationId = "io.newm"
         minSdk = libs.versions.android.minSdk.get().toInt()
         targetSdk = libs.versions.android.targetSdk.get().toInt()
-        versionCode = 5
-        versionName = "0.3.0"
+        versionCode = getCurrentDateTimeVersionCode()
+        versionName = getCustomVersionName(major = 1)
         testInstrumentationRunner = "io.newm.NewmAndroidJUnitRunner"
         testApplicationId = "io.newm.test"
     }
@@ -60,7 +62,11 @@ android {
             dimension = "version"
         }
         all {
-            resValue("string", "account_type", "$applicationId${applicationIdSuffix.orEmpty()}.account")
+            resValue(
+                "string",
+                "account_type",
+                "$applicationId${applicationIdSuffix.orEmpty()}.account"
+            )
         }
     }
 
@@ -123,4 +129,46 @@ sentry {
     // disable if you don't want to expose your sources
     includeSourceContext.set(true)
     telemetry.set(true)
+}
+
+/**
+ * Generates a dynamic `versionCode` based on the current date and hour.
+ *
+ * The `versionCode` is constructed using the format `yyyyMMddHH`, which represents:
+ * - `yyyy`: 4-digit year
+ * - `MM`: 2-digit month (01-12)
+ * - `dd`: 2-digit day of the month (01-31)
+ * - `HH`: 2-digit hour in 24-hour format (00-23)
+ *
+ * This ensures that each build has a unique `versionCode` per hour of the day.
+ *
+ * @return An integer representing the dynamically generated `versionCode`.
+ */
+fun getCurrentDateTimeVersionCode(): Int {
+    val dateFormat = SimpleDateFormat("yyyyMMddHH")
+    return dateFormat.format(Date()).toInt()
+}
+
+/**
+ * Generates a dynamic `versionName` based on a specified major version, current year, month, day, and hour.
+ *
+ * The `versionName` follows the format `Major.Year.MMDDHH`, where:
+ * - `Major`: The major version number provided as an input parameter.
+ * - `Year`: The current year (e.g., 2024).
+ * - `MMDD`: Month and day combined (e.g., 0925 for September 25).
+ * - `HH`: Hour in 24-hour format (00-23).
+ *
+ * @param major The major version number to be included in the `versionName`.
+ * @return A string representing the dynamically generated `versionName`.
+ */
+fun getCustomVersionName(major: Int): String {
+    val yearFormat = SimpleDateFormat("yyyy")
+    val monthDayFormat = SimpleDateFormat("MMdd")
+    val hourFormat = SimpleDateFormat("HH")
+
+    val year = yearFormat.format(Date())
+    val monthDay = monthDayFormat.format(Date())
+    val hour = hourFormat.format(Date())
+
+    return "$major.$year.$monthDay$hour"
 }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -116,7 +116,6 @@ buildConfig {
 	buildConfigField<String>("GOOGLE_AUTH_CLIENT_ID", properties.getProperty("GOOGLE_AUTH_CLIENT_ID").replace("\"", ""))
 	buildConfigField<String>("RECAPTCHA_SITE_KEY", properties.getProperty("RECAPTCHA_SITE_KEY").replace("\"", ""))
 	buildConfigField<String>("SENTRY_AUTH_TOKEN", properties.getProperty("SENTRY_AUTH_TOKEN").replace("\"", ""))
-	buildConfigField<String>("NEWM_MOBILE_APP_VERSION", "0.0.0")
 	buildConfigField<String>("ANDROID_SENTRY_DSN", properties.getProperty("ANDROID_SENTRY_DSN").replace("\"", ""))
 }
 


### PR DESCRIPTION
This PR brings in automatic versioning to simplify our process and keep things consistent.

Automatic `versionCode`: Now generated based on the current date and hour in the format `yyMMddHH`. Each build gets a unique `versionCode`, so you won’t have to worry about updating it manually anymore.

Automatic `versionName`: The `versionName` follows the format `Major.Year.MMDDHH`. The major version is still set manually, but the rest (year, month, day, and hour) is generated automatically, giving us version names that reflect when the build was created.

Manual major version control: We still have full control over the major version, so we can bump it up as needed for big releases or breaking changes.