### PR TITLE
add track duration placeholder

### DIFF
--- a/android/features/music-player/src/main/java/io/newm/feature/musicplayer/MiniPlayer.kt
+++ b/android/features/music-player/src/main/java/io/newm/feature/musicplayer/MiniPlayer.kt
@@ -50,6 +50,7 @@ import io.newm.feature.musicplayer.models.Track
 import io.newm.feature.musicplayer.service.MusicPlayer
 import io.newm.shared.public.analytics.NewmAppEventLogger
 import kotlinx.coroutines.launch
+import kotlin.time.Duration.Companion.seconds
 
 
 @Composable
@@ -146,7 +147,9 @@ fun MiniPlayer(
         ) {
             Column {
                 MusicPlayerSlider(
-                    value = if (playStatus.duration == 0L) 0f else playStatus.position.toFloat() / playStatus.duration.toFloat(),
+                    value = playStatus.duration?.takeIf { it > 0.seconds }
+                        ?.let { duration -> playStatus.position.toFloat() / duration.inWholeMilliseconds }
+                        ?: 0f,
                     onValueChange = {},
                     colors = SliderDefaults.colors(
                         thumbColor = White,

--- a/android/features/music-player/src/main/java/io/newm/feature/musicplayer/MiniPlayer.kt
+++ b/android/features/music-player/src/main/java/io/newm/feature/musicplayer/MiniPlayer.kt
@@ -50,7 +50,6 @@ import io.newm.feature.musicplayer.models.Track
 import io.newm.feature.musicplayer.service.MusicPlayer
 import io.newm.shared.public.analytics.NewmAppEventLogger
 import kotlinx.coroutines.launch
-import kotlin.time.Duration.Companion.seconds
 
 
 @Composable
@@ -147,9 +146,7 @@ fun MiniPlayer(
         ) {
             Column {
                 MusicPlayerSlider(
-                    value = playStatus.duration?.takeIf { it > 0.seconds }
-                        ?.let { duration -> playStatus.position.toFloat() / duration.inWholeMilliseconds }
-                        ?: 0f,
+                    value = playStatus.elapsedFraction,
                     onValueChange = {},
                     colors = SliderDefaults.colors(
                         thumbColor = White,

--- a/android/features/music-player/src/main/java/io/newm/feature/musicplayer/MusicPlayerViewer.kt
+++ b/android/features/music-player/src/main/java/io/newm/feature/musicplayer/MusicPlayerViewer.kt
@@ -66,7 +66,6 @@ import io.newm.feature.musicplayer.viewmodel.PlaybackUiEvent
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import kotlin.time.Duration.Companion.seconds
 
 private val playbackTimeStyle = TextStyle(
     fontSize = 12.sp,
@@ -195,9 +194,7 @@ private fun MusicPlayerControls(
         )
         if (playbackStatus.duration != null) {
             MusicPlayerSlider(
-                value = playbackStatus.duration.takeIf { it > 0.seconds }?.let { duration ->
-                    playbackStatus.position.toFloat() / duration.inWholeMilliseconds
-                } ?: 0f,
+                value = playbackStatus.elapsedFraction,
                 onValueChange = { onEvent(PlaybackUiEvent.Seek((it * playbackStatus.duration.inWholeMilliseconds).toLong())) },
                 colors = SliderDefaults.colors(
                     thumbColor = White,

--- a/android/features/music-player/src/main/java/io/newm/feature/musicplayer/models/PlaybackStatus.kt
+++ b/android/features/music-player/src/main/java/io/newm/feature/musicplayer/models/PlaybackStatus.kt
@@ -1,10 +1,12 @@
 package io.newm.feature.musicplayer.models
 
+import kotlin.time.Duration
+
 data class PlaybackStatus(
     val state: PlaybackState,
     val track: Track?,
     val position: Long,
-    val duration: Long,
+    val duration: Duration?,
     val repeatMode: PlaybackRepeatMode,
     val shuffleMode: Boolean
 ) {
@@ -12,7 +14,7 @@ data class PlaybackStatus(
         val EMPTY: PlaybackStatus = PlaybackStatus(
             state = PlaybackState.STOPPED,
             position = 0,
-            duration = 0,
+            duration = null,
             track = null,
             repeatMode = PlaybackRepeatMode.REPEAT_OFF,
             shuffleMode = false,

--- a/android/features/music-player/src/main/java/io/newm/feature/musicplayer/models/PlaybackStatus.kt
+++ b/android/features/music-player/src/main/java/io/newm/feature/musicplayer/models/PlaybackStatus.kt
@@ -1,6 +1,7 @@
 package io.newm.feature.musicplayer.models
 
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 
 data class PlaybackStatus(
     val state: PlaybackState,
@@ -10,6 +11,12 @@ data class PlaybackStatus(
     val repeatMode: PlaybackRepeatMode,
     val shuffleMode: Boolean
 ) {
+
+    val elapsedFraction : Float get()  {
+        return duration?.takeIf { it > 0.seconds }?.let { duration ->
+           position.toFloat() / duration.inWholeMilliseconds
+        } ?: 0f
+    }
     companion object {
         val EMPTY: PlaybackStatus = PlaybackStatus(
             state = PlaybackState.STOPPED,

--- a/android/features/music-player/src/main/java/io/newm/feature/musicplayer/service/MusicPlayer.kt
+++ b/android/features/music-player/src/main/java/io/newm/feature/musicplayer/service/MusicPlayer.kt
@@ -2,6 +2,7 @@ package io.newm.feature.musicplayer.service
 
 import android.util.Log
 import androidx.core.net.toUri
+import androidx.media3.common.C
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
 import androidx.media3.common.Player
@@ -19,6 +20,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlin.time.Duration.Companion.milliseconds
 
 interface MusicPlayer {
     val playbackStatus: StateFlow<PlaybackStatus>
@@ -84,7 +86,7 @@ class MusicPlayerImpl(
             PlaybackStatus(
                 state = state,
                 position = player.currentPosition,
-                duration = player.duration,
+                duration = if(player.duration == C.TIME_UNSET ) null else player.duration.milliseconds,
                 track = player.currentMediaItem?.toTrack(),
                 repeatMode = repeatMode,
                 shuffleMode = player.shuffleModeEnabled


### PR DESCRIPTION
We currently show `47:04` as the duration for every track while we load the actual duration. This PR makes it so we show a placeholder instead.

- [x] reuse logic for position/duration

**Before**

[Screen_recording_20241002_210406.webm](https://github.com/user-attachments/assets/f0ffa4e4-4b91-4681-acf0-668e14d097eb)


**After**

[Screen_recording_20241002_205345.webm](https://github.com/user-attachments/assets/df1813a9-e670-4e52-8182-9f678fc96284)
